### PR TITLE
Combine memory allocation for exclude_pattern items, simplify loops

### DIFF
--- a/client/castApp/src/caster.c
+++ b/client/castApp/src/caster.c
@@ -120,12 +120,6 @@ void casterInit(caster_t *self)
         errlogPrintf("Error: casterInit failed to create shutdown socket: %d\n", SOCKERRNO);
 }
 
-static void nodeFree(void *node) {
-    string_list_t *temp = (string_list_t *)node;
-    free(temp->item_str);
-    free(temp);
-}
-
 void casterShutdown(caster_t *self)
 {
     int i;
@@ -150,7 +144,7 @@ void casterShutdown(caster_t *self)
     epicsMutexUnlock(self->lock);
 
     epicsMutexMustLock(self->lock);
-    ellFree2(&self->exclude_patterns, &nodeFree);
+    ellFree(&self->exclude_patterns);
     epicsMutexUnlock(self->lock);
 
     epicsEventDestroy(self->shutdownEvent);

--- a/client/castApp/src/dbcb.c
+++ b/client/castApp/src/dbcb.c
@@ -2,6 +2,7 @@
 #include <epicsVersion.h>
 #include <epicsString.h>
 #include <envDefs.h>
+#include <dbDefs.h>
 
 #include <dbStaticLib.h>
 #include <dbAccess.h>
@@ -94,12 +95,10 @@ static int pushRecord(caster_t *caster, DBENTRY *pent)
     if(dbIsAlias(pent))
         return 0;
 
-    cur = ellFirst(&caster->exclude_patterns);
-    while (cur != NULL) {
-        string_list_t *temp = (string_list_t *)cur;
-        if(epicsStrGlobMatch(prec->name, temp->item_str))
+    for(cur = ellFirst(&caster->exclude_patterns); cur; cur = ellNext(cur)) {
+        const string_list_t *ppattern = CONTAINER(cur, string_list_t, node);
+        if(epicsStrGlobMatch(prec->name, ppattern->item_str))
             return 0;
-        cur = ellNext(cur);
     }
 
     rid = casterSendRecord(caster, prec->rdes->name, prec->name);


### PR DESCRIPTION
Based on comments in https://github.com/ChannelFinder/recsync/pull/117